### PR TITLE
Support websocket compression

### DIFF
--- a/jupyter_server_proxy/websocket.py
+++ b/jupyter_server_proxy/websocket.py
@@ -51,11 +51,13 @@ def pingable_ws_connect(request=None, on_message_callback=None,
     # for tornado 4.5.x compatibility
     if version_info[0] == 4:
         conn = PingableWSClientConnection(io_loop=ioloop.IOLoop.current(),
+            compression_options={},
             request=request,
             on_message_callback=on_message_callback,
             on_ping_callback=on_ping_callback)
     else:
         conn = PingableWSClientConnection(request=request,
+            compression_options={},
             on_message_callback=on_message_callback,
             on_ping_callback=on_ping_callback,
             max_message_size=getattr(websocket, '_default_max_message_size', 10 * 1024 * 1024))


### PR DESCRIPTION
`jupyter-server-proxy`'s websocket connection (`PingableWSClientConnection`) does not support WS compression.

When using `jupyter-server-proxy` to proxy a websocket connection, the handshake that occurs during the upgrade only takes into account the proxied websocket server's preferences. That server may (and often will) support compression schemes such as `permessage-deflate`.
In this case, the client will use that compression scheme which will trigger an error in `jupyter-server-proxy` / `tornado` code.

The fix is fairly simple: `PingableWSClientConnection` should support all compression schemes and let the client and the proxied server decide how they should communicate.